### PR TITLE
fix(workshop)

### DIFF
--- a/deployment/workshop/istio-configuration/ingress-loadbalancer.yaml
+++ b/deployment/workshop/istio-configuration/ingress-loadbalancer.yaml
@@ -76,7 +76,7 @@ objects:
     type: ClusterIP
   status:
     loadBalancer: {}
-- apiVersion: extensions/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     annotations:


### PR DESCRIPTION
I was running this using the v1.17 API and there were some deprecated APIs that have been removed.  This PR addresses it.

```
$ oc version
Client Version: 4.4.3
Server Version: 4.4.3
Kubernetes Version: v1.17.1
```

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/